### PR TITLE
Add Dockerfile with compose script and entrypoint

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,9 @@ RUN pip install -r /dakara-server/requirements.txt
 COPY ./ /dakaraneko
 RUN pip install -r dakaraneko/karaneko/requirements.txt
 
-RUN sed -i -e 's+^DAKARA_SERVER_DIR=.*$+DAKARA_SERVER_DIR=/dakara-server+' -e 's+^DAKARANEKO_DIR=.*$+DAKARANEKO_DIR=/dakaraneko+' -e 's+^KARA_DIR=.*$+KARA_DIR=/karabase+' /dakaraneko/feed.sh
+ENV DAKARA_SERVER_DIR=/dakara-server
+ENV DAKARANEKO_DIR=/dakaraneko
+ENV KARA_DIR=/karabase
 
 COPY docker/entrypoint.sh /
 RUN chmod u+x entrypoint.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,22 +1,21 @@
 FROM python:3.6
 
-RUN apt-get update
-RUN apt-get install -y ffmpeg mediainfo
+RUN apt-get update \
+    && apt-get install -y ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
 
-RUN wget $(curl --silent https://api.github.com/repos/DakaraProject/dakara-server/releases/latest | grep browser_download_url | sed -e 's/^.*\": \"//' -e 's/\"$//') -O dakara-server.zip
+COPY docker/get_dakara.sh /
+RUN chmod u+x get_dakara.sh && /get_dakara.sh
 
-RUN unzip dakara-server.zip
-RUN rm dakara-server.zip
-RUN mv dakara-server* /dakara-server
 RUN pip install -r /dakara-server/requirements.txt
 
 RUN cp /dakara-server/dakara_server/dakara_server/local_settings.py.example /dakara-server/dakara_server/dakara_server/local_settings.py
-RUN sed -i "s/^ALLOWED_HOSTS\ =\ \[/ALLOWED_HOSTS\ =\ \[\'\*\'/" /dakara-server/dakara_server/dakara_server/local_settings.py
+RUN sed -i "s/^ALLOWED_HOSTS = \[/ALLOWED_HOSTS = ['*'/" /dakara-server/dakara_server/dakara_server/local_settings.py
 
 COPY ./ /dakaraneko
 RUN pip install -r dakaraneko/karaneko/requirements.txt
 
-RUN sed -i -e 's/^DAKARA_SERVER_DIR=.*$/DAKARA_SERVER_DIR=\/dakara-server/' -e 's/^DAKARANEKO_DIR=.*$/DAKARANEKO_DIR=\/dakaraneko/' -e 's/^KARA_DIR=.*$/KARA_DIR=\/karabase/' /dakaraneko/feed.sh
+RUN sed -i -e 's+^DAKARA_SERVER_DIR=.*$+DAKARA_SERVER_DIR=/dakara-server+' -e 's+^DAKARANEKO_DIR=.*$+DAKARANEKO_DIR=/dakaraneko+' -e 's+^KARA_DIR=.*$+KARA_DIR=/karabase+' /dakaraneko/feed.sh
 
 COPY docker/entrypoint.sh /
 RUN chmod u+x entrypoint.sh

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,9 +9,6 @@ RUN chmod u+x get_dakara.sh && /get_dakara.sh
 
 RUN pip install -r /dakara-server/requirements.txt
 
-RUN cp /dakara-server/dakara_server/dakara_server/local_settings.py.example /dakara-server/dakara_server/dakara_server/local_settings.py
-RUN sed -i "s/^ALLOWED_HOSTS = \[/ALLOWED_HOSTS = ['*'/" /dakara-server/dakara_server/dakara_server/local_settings.py
-
 COPY ./ /dakaraneko
 RUN pip install -r dakaraneko/karaneko/requirements.txt
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.6
+
+RUN apt-get update
+RUN apt-get install -y ffmpeg mediainfo
+
+RUN wget $(curl --silent https://api.github.com/repos/DakaraProject/dakara-server/releases/latest | grep browser_download_url | sed -e 's/^.*\": \"//' -e 's/\"$//') -O dakara-server.zip
+
+RUN unzip dakara-server.zip
+RUN rm dakara-server.zip
+RUN mv dakara-server* /dakara-server
+RUN pip install -r /dakara-server/requirements.txt
+
+RUN cp /dakara-server/dakara_server/dakara_server/local_settings.py.example /dakara-server/dakara_server/dakara_server/local_settings.py
+RUN sed -i "s/^ALLOWED_HOSTS\ =\ \[/ALLOWED_HOSTS\ =\ \[\'\*\'/" /dakara-server/dakara_server/dakara_server/local_settings.py
+
+COPY ./ /dakaraneko
+RUN pip install -r dakaraneko/karaneko/requirements.txt
+
+RUN sed -i -e 's/^DAKARA_SERVER_DIR=.*$/DAKARA_SERVER_DIR=\/dakara-server/' -e 's/^DAKARANEKO_DIR=.*$/DAKARANEKO_DIR=\/dakaraneko/' -e 's/^KARA_DIR=.*$/KARA_DIR=\/karabase/' /dakaraneko/feed.sh
+
+COPY docker/entrypoint.sh /
+RUN chmod u+x entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["run"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,7 +10,7 @@ RUN chmod u+x get_dakara.sh && /get_dakara.sh
 RUN pip install -r /dakara-server/requirements.txt
 
 COPY ./ /dakaraneko
-RUN pip install -r dakaraneko/karaneko/requirements.txt
+RUN pip install -r /dakaraneko/karaneko/requirements.txt
 
 ENV DAKARA_SERVER_DIR=/dakara-server
 ENV DAKARANEKO_DIR=/dakaraneko

--- a/docker/README.md
+++ b/docker/README.md
@@ -42,7 +42,7 @@ Run the `install` command with compose from this directory to setup the server:
 docker-compose run dakara install
 ```
 
-You will be asked to choose the credentials for the server's superuser during the process.
+You will be asked to choose the credentials for the server's superuser, then for the player's account, during the process.
 
 ## Server start
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,58 @@
+# Docker image for Dakara server
+
+Docker setup to manage the server, with automatic configuration and database feeding.
+
+## System requirements
+
+* Docker
+* Docker-compose
+
+## Building
+
+Please note that these instructions assume that you already initialized this repository's submodules (see [the main README](../README.md) for more details)
+
+From this directory, just build the image with compose:
+
+```
+docker-compose build
+```
+
+## Settings
+
+The only thing that you should edit is the [docker-compose.yml](docker-compose.yml) file.
+
+### Port setup
+
+By default, the port that will be used to run the server on the host is `8080`.
+To change it, you can edit the `ports` section with:
+
+```
+      - "WHATEVER_PORT:22222"
+```
+
+### Kara base folder
+
+To set the folder in which you store your karas, you need to edit the `/path/to/kara/base` part in the `volumes` section with the actual path on your host.
+
+### Server setup
+
+Run the `install` command with compose from this directory to setup the server:
+
+```
+docker-compose run dakara install
+```
+
+You will be asked to choose the credentials for the server's superuser during the process.
+
+## Server start
+
+To start the server, simply start the container with compose from this directory:
+
+```
+docker-compose up
+```
+
+This will also manage the feeding of the database, so the first start might take a **very** long time depending on the number of karas you own.
+
+To stop the server, simply type `^C` and wait for a bit.
+

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,13 @@
+version: '3'
+services:
+  dakara:
+    container_name: dakara
+    build:
+      context: ../
+      dockerfile: docker/Dockerfile
+    restart: always
+    ports:
+      - "8080:22222"
+    volumes:
+      - ./db:/db
+      - /path/to/kara/base:/karabase

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     build:
       context: ../
       dockerfile: docker/Dockerfile
-    restart: always
+    restart: unless-stopped
     ports:
       - "8080:22222"
     volumes:

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+if [ ! -f /db/db.sqlite3 ] ; then
+  touch /db/db.sqlite3
+fi
+ln -s /db/db.sqlite3 /dakara-server/dakara_server/db.sqlite3
+
+if [ "$1" == "install" ]; then
+  /dakara-server/dakara_server/manage.py migrate
+  /dakara-server/dakara_server/manage.py createsuperuser
+  /dakara-server/dakara_server/manage.py createtags /dakaraneko/config.yaml
+  /dakara-server/dakara_server/manage.py createworktypes /dakaraneko/config.yaml
+elif [ "$1" == "run" ]; then
+  /dakaraneko/feed.sh
+  /dakara-server/dakara_server/manage.py runserver 0.0.0.0:22222
+fi

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -8,6 +8,7 @@ ln -s /db/db.sqlite3 /dakara-server/dakara_server/db.sqlite3
 if [ "$1" == "install" ]; then
   /dakara-server/dakara_server/manage.py migrate
   /dakara-server/dakara_server/manage.py createsuperuser
+  /dakara-server/dakara_server/manage.py createplayer
   /dakara-server/dakara_server/manage.py createtags /dakaraneko/config.yaml
   /dakara-server/dakara_server/manage.py createworktypes /dakaraneko/config.yaml
 elif [ "$1" == "run" ]; then

--- a/docker/get_dakara.sh
+++ b/docker/get_dakara.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+wget $(curl --silent https://api.github.com/repos/DakaraProject/dakara-server/releases/latest | grep browser_download_url | sed -e 's/^.*\": \"//' -e 's/\"$//') -O dakara-server.zip
+
+unzip dakara-server.zip
+rm dakara-server.zip
+mv dakara-server* /dakara-server

--- a/feed.sh
+++ b/feed.sh
@@ -5,10 +5,13 @@
 #
 
 set -e
-DAKARA_SERVER_DIR=/path/to/dakara-server
-DAKARANEKO_DIR=/path/to/dakaraneko
-KARA_DIR=/path/to/karaoke_folder/
+
+: ${DAKARA_SERVER_DIR:=/path/to/dakara-server}
+: ${DAKARANEKO_DIR:=/path/to/dakaraneko}
+: ${KARA_DIR:=/path/to/karaoke_folder/}
+
 OPTIONS="--prune --append-only"
+
 cd ${DAKARA_SERVER_DIR}/dakara_server
 
 # Activate virtualenv (uncomment to use it)


### PR DESCRIPTION
This PR contains:
  - a Dockerfile to create a docker image for the lastest released version of dakara-server
  - an entrypoint to create the database, do a basic configuration (migrations, superuser and tags/wt creation) and run the server after a feed
  - a docker-compose file to set the server port and the path to the kara base